### PR TITLE
Rename distributed_backend -> strategy in tools/train_net.py for pytorch-lightning 1.5 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,9 @@ fvcore
 dosma>=0.1.0
 iopath
 medpy
+packaging
 pandas
-tqdm
+tqdm>=4.42.0
 xlrd
 monai>=0.3.0
 meddlr

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(
         "dosma>=0.1.0",
         "iopath",
         "medpy",
+        "packaging",
         "pandas",
         "tqdm>=4.42.0",
         "xlrd",


### PR DESCRIPTION
pytorch-lightning renamed `distributed_backend` to `strategy` in v1.5.0. This PR accommodates this change