### PR TITLE
Add utility for downloading SKM-TEA mini dataset

### DIFF
--- a/skm_tea/data/register.py
+++ b/skm_tea/data/register.py
@@ -1,4 +1,5 @@
 """General utilities for the SKM-TEA dataset."""
+import itertools
 import json
 import logging
 import os
@@ -464,9 +465,9 @@ def download_skm_tea_mini(
 
     files_map = {
         "raw_data": ["files_recon_calib-24", "segmentation_masks"],
-        "dicom_files": ["dicoms", "image_files", "segmentation_masks"],
+        "dicom": ["dicoms", "image_files", "segmentation_masks"],
     }
-    files_map[None] = set(sum(list(x) for x in files_map.values()))
+    files_map[None] = set(itertools.chain(*files_map.values()))
 
     if track not in files_map:
         raise ValueError(f"Track {track} not supported. Must be one of {files_map.keys()}")

--- a/tests/data/test_register.py
+++ b/tests/data/test_register.py
@@ -1,0 +1,7 @@
+from skm_tea.data.register import download_skm_tea_mini
+
+
+def test_download_skm_tea_mini(tmpdir):
+    """Test download skm_tea_mini."""
+    output_dir = download_skm_tea_mini(track="dicom", download_path=tmpdir, force=True)
+    assert str(output_dir) == str(tmpdir)


### PR DESCRIPTION
- Download SKM-TEA mini with wget | tar pipe - faster than using `tarfile` or `wget`